### PR TITLE
Add synthetic data generated with RHEL AI

### DIFF
--- a/scenarios/hotels/results/sdg/datasets/2025-03-28_103209/.gitattributes
+++ b/scenarios/hotels/results/sdg/datasets/2025-03-28_103209/.gitattributes
@@ -1,0 +1,1 @@
+*.jsonl filter=lfs diff=lfs merge=lfs -text

--- a/scenarios/hotels/results/sdg/datasets/2025-03-28_103209/knowledge_recipe_2025-03-28T10_33_14.yaml
+++ b/scenarios/hotels/results/sdg/datasets/2025-03-28_103209/knowledge_recipe_2025-03-28T10_33_14.yaml
@@ -1,0 +1,7 @@
+datasets:
+- path: node_datasets_2025-03-28T10_33_14/knowledge_geography_travel_europe_m3diterraneo_hotels_p07.jsonl
+  sampling_size: 1.0
+metadata:
+  sys_prompt: "I am a Red Hat\xAE Instruct Model, an AI language model developed by\
+    \ Red Hat and IBM Research based on the granite-3.1-8b-base model. My primary\
+    \ role is to serve as a chat assistant."

--- a/scenarios/hotels/results/sdg/datasets/2025-03-28_103209/knowledge_train_msgs_2025-03-28T10_33_14.jsonl
+++ b/scenarios/hotels/results/sdg/datasets/2025-03-28_103209/knowledge_train_msgs_2025-03-28T10_33_14.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f23ed1dc39c8119b0b7accb70fdbdd318d3bc95abdc3af290d4f127bc85c3a4f
+size 7493274

--- a/scenarios/hotels/results/sdg/datasets/2025-03-28_103209/messages_2025-03-28T10_33_14.jsonl
+++ b/scenarios/hotels/results/sdg/datasets/2025-03-28_103209/messages_2025-03-28T10_33_14.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c74b1b981e54cfa45a50f7e15b8d6c761b9c122f61be4f4219c266f9817f986
+size 1106820

--- a/scenarios/hotels/results/sdg/datasets/2025-03-28_103209/skills_recipe_2025-03-28T10_33_14.yaml
+++ b/scenarios/hotels/results/sdg/datasets/2025-03-28_103209/skills_recipe_2025-03-28T10_33_14.yaml
@@ -1,0 +1,13 @@
+datasets:
+- path: /usr/share/instructlab/sdg/datasets/skills.jsonl
+  sampling_size: 1.0
+- path: node_datasets_2025-03-28T10_33_14/compositional_skills_technology_hotels_m3diterraneo_hotels_guests_welcoming.jsonl
+  sampling_size: 30
+- path: node_datasets_2025-03-28T10_33_14/compositional_skills_technology_hotels_m3diterraneo_hotels_upselling.jsonl
+  sampling_size: 30
+- path: node_datasets_2025-03-28T10_33_14/knowledge_geography_travel_europe_m3diterraneo_hotels_p10.jsonl
+  sampling_size: 10392
+metadata:
+  sys_prompt: "I am a Red Hat\xAE Instruct Model, an AI language model developed by\
+    \ Red Hat and IBM Research based on the granite-3.1-8b-base model. My primary\
+    \ role is to serve as a chat assistant."

--- a/scenarios/hotels/results/sdg/datasets/2025-03-28_103209/skills_train_msgs_2025-03-28T10_33_14.jsonl
+++ b/scenarios/hotels/results/sdg/datasets/2025-03-28_103209/skills_train_msgs_2025-03-28T10_33_14.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1412fe2c77400dce7c0cff36788c6fcd4c530c9b81a96a877fa5884e60cd856f
+size 1752042579

--- a/scenarios/hotels/results/sdg/datasets/2025-03-28_103209/skills_train_reduced_10000_samples.jsonl
+++ b/scenarios/hotels/results/sdg/datasets/2025-03-28_103209/skills_train_reduced_10000_samples.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5019ebba669a913b79834317e38d362b02b52442694f7e2d85f6f4ca5d6691a
+size 48702245

--- a/scenarios/hotels/results/sdg/datasets/2025-03-28_103209/test_2025-03-28T10_33_14.jsonl
+++ b/scenarios/hotels/results/sdg/datasets/2025-03-28_103209/test_2025-03-28T10_33_14.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41d00c54ee3a08f6c7e44a9d7a9ce085b0c6762821b2f01297360c55a5bd6600
+size 309037

--- a/scenarios/hotels/results/sdg/datasets/2025-03-28_103209/train_2025-03-28T10_33_14.jsonl
+++ b/scenarios/hotels/results/sdg/datasets/2025-03-28_103209/train_2025-03-28T10_33_14.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d42c29ff6383ad7072c86b489b23319ef5c6b521f00b4d9f8dedd91d086202d
+size 992124


### PR DESCRIPTION
This is the synthetic data generated as a result of running a standard `ilab data generate` command on a RHEL AI  instance with 4xL40S GPUs. The taxonomy that we have used is https://github.com/RedHatTraining/AI296-taxonomy-hotels/tree/860e2edd93f722caff9ed0c5c17a785dc0b93d7e



